### PR TITLE
Fix spontaneous turn on at power cut

### DIFF
--- a/fw/adc.c
+++ b/fw/adc.c
@@ -7,6 +7,7 @@
 #include "isl94208.h"
 
 
+#define IDLE_THRESHOLD                  (40)
 #define BUTTON_PRESSED_THRESHOLD        (80)
 #define CHARGER_CONNECTED_THRESHOLD     (720)
 
@@ -85,3 +86,9 @@ bool adc_is_charger_connected(void)
 {
     return button_charger_val > CHARGER_CONNECTED_THRESHOLD;
 }
+
+bool adc_ctrl_idle(void)
+{
+    return button_charger_val < IDLE_THRESHOLD;
+}
+

--- a/fw/adc.h
+++ b/fw/adc.h
@@ -45,3 +45,7 @@ bool adc_is_button_pressed(void);
  */
 bool adc_is_charger_connected(void);
 
+/**
+ * Check if neither charger nor button is active and input is in idle state
+ */
+bool adc_ctrl_idle(void);


### PR DESCRIPTION
Fixes https://github.com/dr-mark-roberts/open-dyson-battery/issues/1

This PR adds additional state **WAIT_IDLE**. This state is used when the charger is disappeared but control input voltage hasn't  reached the idle state. In other words to ignore erroneous transition through "button pressed" voltage level.